### PR TITLE
Fix CICD to work when you only push a tag

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -2,9 +2,10 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
+    tags: [ "**" ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   build:


### PR DESCRIPTION
Now releases will actually be created when you do


![image](https://user-images.githubusercontent.com/32943174/153753339-3f3a9d5f-d4bb-4ca8-bbea-53f2019dbfe0.png)

![image](https://user-images.githubusercontent.com/32943174/153753369-29ea17c2-7d47-4806-a36f-02dcafc5953c.png)

