### PR TITLE
Fixed open action for bankBooth

### DIFF
--- a/src/main/java/rsb/methods/Bank.java
+++ b/src/main/java/rsb/methods/Bank.java
@@ -469,7 +469,7 @@ public class Bank extends MethodProvider {
 			if (lowestDist < 5 && methods.calc.tileOnMap(tile) && methods.calc.canReach(tile, true)) {
 				boolean didAction = false;
 				if (bankBooth != null) {
-					didAction = bankBooth.doAction("Use-Quickly");
+					didAction = bankBooth.doAction("Bank") || bankBooth.doAction("Use-Quickly");
 				} else if (banker != null) {
 					didAction = banker.doAction("Bank", "Banker");
 				} else if (bankChest != null) {


### PR DESCRIPTION
All bank booths i saw have now "Bank" action, but i left "Use-Quickly" as secondary just in case