### PR TITLE
Allow User to run bot without specifying an Account in the manager

### DIFF
--- a/src/main/java/net/runelite/rsb/botLauncher/BotLite.java
+++ b/src/main/java/net/runelite/rsb/botLauncher/BotLite.java
@@ -216,15 +216,13 @@ public class BotLite extends RuneLite implements BotLiteInterface {
      * @return  If the account existed already
      */
     public boolean setAccount(final String name) {
-        boolean exist = false;
-        for (String s : AccountManager.getAccountNames()) {
-            if (s.toLowerCase().equals(name.toLowerCase())) {
-                exist = true;
+        if (name != null) {
+            for (String s : AccountManager.getAccountNames()) {
+                if (s.toLowerCase().equals(name.toLowerCase())) {
+                    account = name;
+                    return true;
+                }
             }
-        }
-        if (exist) {
-            account = name;
-            return true;
         }
         account = null;
         return false;

--- a/src/main/java/net/runelite/rsb/script/Script.java
+++ b/src/main/java/net/runelite/rsb/script/Script.java
@@ -244,7 +244,7 @@ public abstract class Script extends Methods implements EventListener, Runnable 
 			try {
 				while (running) {
 					if (!paused) {
-						if (AccountManager.isTakingBreaks(account.getName())) {
+						if (account.getName() != null && AccountManager.isTakingBreaks(account.getName())) {
 							BreakHandler h = ctx.runeLite.getBreakHandler();
 							if (h.isBreaking()) {
 								if (System.currentTimeMillis() - lastNotice > 600000) {


### PR DESCRIPTION
changes in botlauncher fixes the following:
[QUIET] [system.out] java.lang.NullPointerException: null
[QUIET] [system.out] 	at java.base/java.util.Objects.requireNonNull(Objects.java:208)
[QUIET] [system.out] 	at java.base/java.util.TreeMap.getEntry(TreeMap.java:345)
[QUIET] [system.out] 	at java.base/java.util.TreeMap.get(TreeMap.java:279)
[QUIET] [system.out] 	at net.runelite.rsb.util.AccountStore.get(AccountStore.java:99)
[QUIET] [system.out] 	at net.runelite.rsb.plugin.AccountManager.isTakingBreaks(AccountManager.java:366)
2022-08-13T15:05:50.411-0400 [QUIET] [system.out] 	at net.runelite.rsb.script.Script.run(Script.java:247)
2022-08-13T15:05:50.411-0400 [QUIET] [system.out] 	at java.base/java.lang.Thread.run(Thread.java:833)
2022-08-13T15:05:50.411-0400 [QUIET] [system.out] 2022-08-13 15:05:50 [Script-Recorder] INFO  net.runelite.rsb.script.Script - Script stopped.

We also need a null check in Script; since another error will be thrown when trying to check if the non-existing account has the break UI option set.
