### PR TITLE
Make equipment not open interface when querying. (API BREAKING)

### DIFF
--- a/src/main/java/net/runelite/client/modified/BotModule.java
+++ b/src/main/java/net/runelite/client/modified/BotModule.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.google.common.math.DoubleMath;
 import com.google.gson.Gson;
 import com.google.inject.AbstractModule;
+
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.binder.ConstantBindingBuilder;
@@ -54,6 +55,8 @@ public class BotModule extends AbstractModule {
     private final File config;
     private boolean disableTelemetry = false;
 
+    private final String profile = "default";
+    private final boolean insecureWriteCredentials = false;
 
     public BotModule(OkHttpClient okHttpClient, Supplier<Applet> clientLoader, RuntimeConfigLoader configSupplier, boolean developerMode, boolean safeMode, File sessionfile, File config) {
         this.okHttpClient = okHttpClient;
@@ -115,6 +118,12 @@ public class BotModule extends AbstractModule {
             bind(Scheduler.class);
             bind(PluginManager.class);
             bind(SessionManager.class);
+
+
+            bind(String.class).annotatedWith(Names.named("profile")).toProvider(Providers.of(profile));
+            bindConstant().annotatedWith(Names.named("insecureWriteCredentials")).to(insecureWriteCredentials);
+            bind(File.class).annotatedWith(Names.named("runeLiteDir")).toInstance(RuneLite.RUNELITE_DIR);
+
 
             bind(Gson.class).toInstance(RuneLiteAPI.GSON);
 

--- a/src/main/java/net/runelite/rsb/botLauncher/Application.java
+++ b/src/main/java/net/runelite/rsb/botLauncher/Application.java
@@ -51,7 +51,8 @@ public class Application {
 		String spriteCacheLocation = GlobalConfiguration.Paths.getSpritesCacheDirectory();
 		//TODO Some sort of better validation here
 		//Add a version check
-		if (!new File(itemCacheLocation).exists() && new File(itemCacheLocation).getTotalSpace() < 100) {
+
+		if ((!new File(itemCacheLocation).exists()) || new File(itemCacheLocation).getTotalSpace() < 100) {
 			String[] itemArgs = {"--cache", gameCacheLocation,
 					"--items", itemCacheLocation};
 			String[] objectArgs = {"--cache", gameCacheLocation,

--- a/src/main/java/net/runelite/rsb/methods/Combat.java
+++ b/src/main/java/net/runelite/rsb/methods/Combat.java
@@ -49,6 +49,9 @@ public class Combat extends MethodProvider {
 			if (!methods.inventory.contains(food)) {
 				continue;
 			}
+			if (!methods.inventory.open()) {
+				return false;
+			}
 			if (methods.inventory.getItem(food).doAction("Eat")) {
 				for (int i = 0; i < 100; i++) {
 					sleep(random(100, 300));
@@ -75,6 +78,9 @@ public class Combat extends MethodProvider {
 		int firstPercent = getHealth();
 		RSItem[] edibleItems = methods.inventory.getAllWithAction("Eat");
 		if (edibleItems == null || edibleItems.length == 0) {
+			return false;
+		}
+		if (!methods.inventory.open()) {
 			return false;
 		}
 		for (RSItem edibleItem : edibleItems) {

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -79,7 +79,7 @@ public class Equipment extends MethodProvider {
 				items.add(new RSItem(methods, slotItem, cachedItems[i]));
 			}
 		}
-		return (RSItem[]) items.toArray();
+		return items.toArray(new RSItem[0]);
 	}
 
 	/**

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -68,7 +68,7 @@ public class Equipment extends MethodProvider {
 		RSItem[] items = new RSItem[EQUIPMENT_ITEM_SLOTS];
 		ItemContainer container = methods.client.getItemContainer(InventoryID.EQUIPMENT);
 		if (container == null) {
-			return null;
+			return new RSItem[]{};
 		}
 		Item[] cachedItems = container.getItems();
 		for (int i = 0; i < cachedItems.length; i++) {

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -49,7 +49,7 @@ public class Equipment extends MethodProvider {
 		if (container == null) {
 			return null;
 		}
-		Item[] cachedItems = methods.client.getItemContainer(InventoryID.EQUIPMENT).getItems();
+		Item[] cachedItems = container.getItems();
 		for (int i = 0; i < cachedItems.length; i++) {
 			if (cachedItems[i].getId() != -1) {
 				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
@@ -70,7 +70,7 @@ public class Equipment extends MethodProvider {
 		if (container == null) {
 			return null;
 		}
-		Item cachedItem = methods.client.getItemContainer(InventoryID.EQUIPMENT).getItem(index + 1);
+		Item cachedItem = container.getItem(index + 1);
 		RSWidget widget = getInterface().getComponent(index);
 		return cachedItem == null ? null : new RSItem(methods, widget, cachedItem);
 	}

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -2,6 +2,7 @@ package net.runelite.rsb.methods;
 
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.rsb.internal.globval.WidgetIndices;
 import net.runelite.rsb.internal.globval.enums.InterfaceTab;
 import net.runelite.rsb.wrappers.RSItem;
@@ -44,10 +45,16 @@ public class Equipment extends MethodProvider {
 	public RSItem[] getItems() {
 		getInterface();
 		RSItem[] items = new RSItem[EQUIPMENT_ITEM_SLOTS];
+		ItemContainer container = methods.client.getItemContainer(InventoryID.EQUIPMENT);
+		if (container == null) {
+			return null;
+		}
 		Item[] cachedItems = methods.client.getItemContainer(InventoryID.EQUIPMENT).getItems();
-		for (int i = 0; i < items.length; i++) {
-			RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
-			items[i] = new RSItem(methods, slotItem, cachedItems[i]);
+		for (int i = 0; i < cachedItems.length; i++) {
+			if (cachedItems[i].getId() != -1) {
+				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
+				items[i] = new RSItem(methods, slotItem, cachedItems[i]);
+			}
 		}
 		return items;
 	}
@@ -59,7 +66,13 @@ public class Equipment extends MethodProvider {
 	 * @return The equipped item.
 	 */
 	public RSItem getItem(int index) {
-		return new RSItem(methods, getInterface().getComponent(index), methods.client.getItemContainer(InventoryID.EQUIPMENT).getItem(index + 1));
+		ItemContainer container = methods.client.getItemContainer(InventoryID.EQUIPMENT);
+		if (container == null) {
+			return null;
+		}
+		Item cachedItem = methods.client.getItemContainer(InventoryID.EQUIPMENT).getItem(index + 1);
+		RSWidget widget = getInterface().getComponent(index);
+		return cachedItem == null ? null : new RSItem(methods, widget, cachedItem);
 	}
 
 

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -70,7 +70,7 @@ public class Equipment extends MethodProvider {
 		if (container == null) {
 			return null;
 		}
-		Item cachedItem = container.getItem(index + 1);
+		Item cachedItem = container.getItem(index);
 		RSWidget widget = getInterface().getComponent(index);
 		return cachedItem == null ? null : new RSItem(methods, widget, cachedItem);
 	}

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -9,6 +9,8 @@ import net.runelite.rsb.internal.globval.enums.InterfaceTab;
 import net.runelite.rsb.wrappers.RSItem;
 import net.runelite.rsb.wrappers.RSWidget;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -65,7 +67,7 @@ public class Equipment extends MethodProvider {
 	 */
 	public RSItem[] getItems() {
 		getInterface();
-		RSItem[] items = new RSItem[EQUIPMENT_ITEM_SLOTS];
+		List<RSItem> items = new ArrayList<RSItem>();
 		ItemContainer container = methods.client.getItemContainer(InventoryID.EQUIPMENT);
 		if (container == null) {
 			return new RSItem[]{};
@@ -74,10 +76,10 @@ public class Equipment extends MethodProvider {
 		for (int i = 0; i < cachedItems.length; i++) {
 			if (cachedItems[i].getId() != -1) {
 				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, runeliteIndexToWidgetChildIndex.get(i)).getDynamicComponent(1);
-				items[i] = new RSItem(methods, slotItem, cachedItems[i]);
+				items.add(new RSItem(methods, slotItem, cachedItems[i]));
 			}
 		}
-		return items;
+		return (RSItem[]) items.toArray();
 	}
 
 	/**

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -1,5 +1,6 @@
 package net.runelite.rsb.methods;
 
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -8,13 +9,29 @@ import net.runelite.rsb.internal.globval.enums.InterfaceTab;
 import net.runelite.rsb.wrappers.RSItem;
 import net.runelite.rsb.wrappers.RSWidget;
 
+import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Equipment related operations.
  */
 public class Equipment extends MethodProvider {
 	private static final int EQUIPMENT_ITEM_SLOTS = 11;
+	static final Map<Integer, Integer> runeliteIndexToWidgetChildIndex = Stream.of(new Integer[][] {
+			{ EquipmentInventorySlot.HEAD.getSlotIdx(), WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.CAPE.getSlotIdx(), WidgetIndices.WornEquipmentTab.CAPE_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.AMULET.getSlotIdx(), WidgetIndices.WornEquipmentTab.AMULET_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.WEAPON.getSlotIdx(), WidgetIndices.WornEquipmentTab.WEAPON_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.BODY.getSlotIdx(), WidgetIndices.WornEquipmentTab.BODY_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.SHIELD.getSlotIdx(), WidgetIndices.WornEquipmentTab.SHIELD_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.LEGS.getSlotIdx(), WidgetIndices.WornEquipmentTab.LEGS_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.GLOVES.getSlotIdx(), WidgetIndices.WornEquipmentTab.GLOVES_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.BOOTS.getSlotIdx(), WidgetIndices.WornEquipmentTab.BOOTS_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.RING.getSlotIdx(), WidgetIndices.WornEquipmentTab.RING_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.AMMO.getSlotIdx(), WidgetIndices.WornEquipmentTab.AMMO_DYNAMIC_CONTAINER }
+	}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 
 	Equipment(final MethodContext ctx) {
 		super(ctx);
@@ -37,6 +54,10 @@ public class Equipment extends MethodProvider {
 		return methods.game.openTab(InterfaceTab.EQUIPMENT);
 	}
 
+	public static int getRuneliteIndexToWidgetChildIndex(int index) {
+		return runeliteIndexToWidgetChildIndex.get(index);
+	}
+
 	/**
 	 * Gets the equipment array.
 	 *
@@ -52,7 +73,7 @@ public class Equipment extends MethodProvider {
 		Item[] cachedItems = container.getItems();
 		for (int i = 0; i < cachedItems.length; i++) {
 			if (cachedItems[i].getId() != -1) {
-				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
+				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, runeliteIndexToWidgetChildIndex.get(i)).getDynamicComponent(1);
 				items[i] = new RSItem(methods, slotItem, cachedItems[i]);
 			}
 		}
@@ -62,7 +83,7 @@ public class Equipment extends MethodProvider {
 	/**
 	 * Gets the equipment item at a given index.
 	 *
-	 * @param index The item index.
+	 * @param index The item index. See EquipmentInventorySlot
 	 * @return The equipped item.
 	 */
 	public RSItem getItem(int index) {
@@ -71,10 +92,19 @@ public class Equipment extends MethodProvider {
 			return null;
 		}
 		Item cachedItem = container.getItem(index);
-		RSWidget widget = getInterface().getComponent(index);
+		RSWidget widget = getInterface().getComponent(runeliteIndexToWidgetChildIndex.get(index));
 		return cachedItem == null ? null : new RSItem(methods, widget, cachedItem);
 	}
 
+	/**
+	 * Gets the equipment item at a given index.
+	 *
+	 * @param index The item index. See EquipmentInventorySlot
+	 * @return The equipped item.
+	 */
+	public RSItem getItem(EquipmentInventorySlot index) {
+		return getItem(index.getSlotIdx());
+	}
 
 	public RSItem[] find(final Predicate<RSItem> filter) {
 		RSItem[] rsItems = getItems();

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -59,7 +59,7 @@ public class Equipment extends MethodProvider {
 	 * @return The equipped item.
 	 */
 	public RSItem getItem(int index) {
-		return new RSItem(methods, getInterface().getComponent(index), methods.client.getItemContainer(InventoryID.EQUIPMENT).getItem(index));
+		return new RSItem(methods, getInterface().getComponent(index), methods.client.getItemContainer(InventoryID.EQUIPMENT).getItem(index + 1));
 	}
 
 

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -1,5 +1,6 @@
 package net.runelite.rsb.methods;
 
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -8,13 +9,29 @@ import net.runelite.rsb.internal.globval.enums.InterfaceTab;
 import net.runelite.rsb.wrappers.RSItem;
 import net.runelite.rsb.wrappers.RSWidget;
 
+import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Equipment related operations.
  */
 public class Equipment extends MethodProvider {
 	private static final int EQUIPMENT_ITEM_SLOTS = 11;
+	static final Map<Integer, Integer> runeliteIndexToWidgetChildIndex = Stream.of(new Integer[][] {
+			{ EquipmentInventorySlot.HEAD.getSlotIdx(), WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.CAPE.getSlotIdx(), WidgetIndices.WornEquipmentTab.CAPE_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.AMULET.getSlotIdx(), WidgetIndices.WornEquipmentTab.AMULET_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.WEAPON.getSlotIdx(), WidgetIndices.WornEquipmentTab.WEAPON_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.BODY.getSlotIdx(), WidgetIndices.WornEquipmentTab.BODY_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.SHIELD.getSlotIdx(), WidgetIndices.WornEquipmentTab.SHIELD_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.LEGS.getSlotIdx(), WidgetIndices.WornEquipmentTab.LEGS_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.GLOVES.getSlotIdx(), WidgetIndices.WornEquipmentTab.GLOVES_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.BOOTS.getSlotIdx(), WidgetIndices.WornEquipmentTab.BOOTS_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.RING.getSlotIdx(), WidgetIndices.WornEquipmentTab.RING_DYNAMIC_CONTAINER },
+			{ EquipmentInventorySlot.AMMO.getSlotIdx(), WidgetIndices.WornEquipmentTab.AMMO_DYNAMIC_CONTAINER }
+	}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 
 	Equipment(final MethodContext ctx) {
 		super(ctx);
@@ -37,6 +54,10 @@ public class Equipment extends MethodProvider {
 		return methods.game.openTab(InterfaceTab.EQUIPMENT);
 	}
 
+	public static int getRuneliteIndexToWidgetChildIndex(int index) {
+		return runeliteIndexToWidgetChildIndex.get(index);
+	}
+
 	/**
 	 * Gets the equipment array.
 	 *
@@ -52,7 +73,7 @@ public class Equipment extends MethodProvider {
 		Item[] cachedItems = container.getItems();
 		for (int i = 0; i < cachedItems.length; i++) {
 			if (cachedItems[i].getId() != -1) {
-				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
+				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, runeliteIndexToWidgetChildIndex.get(i)).getDynamicComponent(1);
 				items[i] = new RSItem(methods, slotItem, cachedItems[i]);
 			}
 		}
@@ -62,7 +83,7 @@ public class Equipment extends MethodProvider {
 	/**
 	 * Gets the equipment item at a given index.
 	 *
-	 * @param index The item index.
+	 * @param index The item index. See EquipmentInventorySlot
 	 * @return The equipped item.
 	 */
 	public RSItem getItem(int index) {
@@ -71,7 +92,7 @@ public class Equipment extends MethodProvider {
 			return null;
 		}
 		Item cachedItem = container.getItem(index);
-		RSWidget widget = getInterface().getComponent(index);
+		RSWidget widget = getInterface().getComponent(runeliteIndexToWidgetChildIndex.get(index));
 		return cachedItem == null ? null : new RSItem(methods, widget, cachedItem);
 	}
 

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -1,5 +1,7 @@
 package net.runelite.rsb.methods;
 
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
 import net.runelite.rsb.internal.globval.WidgetIndices;
 import net.runelite.rsb.internal.globval.enums.InterfaceTab;
 import net.runelite.rsb.wrappers.RSItem;
@@ -22,20 +24,16 @@ public class Equipment extends MethodProvider {
 	 *
 	 * @return the equipment interface
 	 */
-	public RSWidget getInterface() {
-		return getInterface(true);
+	private RSWidget getInterface() {
+		return methods.interfaces.get(WidgetIndices.WornEquipmentTab.GROUP_INDEX);
 	}
 
-	private RSWidget getInterface(boolean update) {
-		// Tab needs to be open for it to update its content -.-
-		if (update && methods.game.getCurrentTab() != InterfaceTab.EQUIPMENT) {
-			if (methods.bank.isOpen()) {
-				methods.bank.close();
-			}
-			methods.game.openTab(InterfaceTab.EQUIPMENT);
-			sleep(random(900, 1500));
-		}
-		return methods.interfaces.get(WidgetIndices.WornEquipmentTab.GROUP_INDEX);
+	public boolean isOpen() {
+		return methods.game.getCurrentTab() == InterfaceTab.EQUIPMENT;
+	}
+
+	public boolean open() {
+		return methods.game.openTab(InterfaceTab.EQUIPMENT);
 	}
 
 	/**
@@ -44,27 +42,12 @@ public class Equipment extends MethodProvider {
 	 * @return An array containing all equipped items
 	 */
 	public RSItem[] getItems() {
-		getInterface(true);
+		getInterface();
 		RSItem[] items = new RSItem[EQUIPMENT_ITEM_SLOTS];
+		Item[] cachedItems = methods.client.getItemContainer(InventoryID.EQUIPMENT).getItems();
 		for (int i = 0; i < items.length; i++) {
 			RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
-			items[i] = new RSItem(methods, slotItem);
-		}
-		return items;
-	}
-
-	/**
-	 * Gets the cached equipment array (i.e. does not open the interface).
-	 *
-	 * @return The items equipped as seen when the equipment tab was last
-	 *         opened.
-	 */
-	private RSItem[] getCachedItems() {
-		RSWidget[] equipment = getInterface(false).getComponents();
-		RSItem[] items = new RSItem[EQUIPMENT_ITEM_SLOTS];
-		for (int i = 0; i < items.length; i++) {
-			RSWidget slotItem = equipment[i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER].getDynamicComponent(1);
-			items[i] = new RSItem(methods, slotItem);
+			items[i] = new RSItem(methods, slotItem, cachedItems[i]);
 		}
 		return items;
 	}
@@ -76,7 +59,7 @@ public class Equipment extends MethodProvider {
 	 * @return The equipped item.
 	 */
 	public RSItem getItem(int index) {
-		return new RSItem(methods, getInterface().getComponent(index));
+		return new RSItem(methods, getInterface().getComponent(index), methods.client.getItemContainer(InventoryID.EQUIPMENT).getItem(index));
 	}
 
 

--- a/src/main/java/net/runelite/rsb/methods/Equipment.java
+++ b/src/main/java/net/runelite/rsb/methods/Equipment.java
@@ -1,6 +1,5 @@
 package net.runelite.rsb.methods;
 
-import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -9,29 +8,13 @@ import net.runelite.rsb.internal.globval.enums.InterfaceTab;
 import net.runelite.rsb.wrappers.RSItem;
 import net.runelite.rsb.wrappers.RSWidget;
 
-import java.util.Map;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Equipment related operations.
  */
 public class Equipment extends MethodProvider {
 	private static final int EQUIPMENT_ITEM_SLOTS = 11;
-	static final Map<Integer, Integer> runeliteIndexToWidgetChildIndex = Stream.of(new Integer[][] {
-			{ EquipmentInventorySlot.HEAD.getSlotIdx(), WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.CAPE.getSlotIdx(), WidgetIndices.WornEquipmentTab.CAPE_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.AMULET.getSlotIdx(), WidgetIndices.WornEquipmentTab.AMULET_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.WEAPON.getSlotIdx(), WidgetIndices.WornEquipmentTab.WEAPON_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.BODY.getSlotIdx(), WidgetIndices.WornEquipmentTab.BODY_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.SHIELD.getSlotIdx(), WidgetIndices.WornEquipmentTab.SHIELD_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.LEGS.getSlotIdx(), WidgetIndices.WornEquipmentTab.LEGS_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.GLOVES.getSlotIdx(), WidgetIndices.WornEquipmentTab.GLOVES_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.BOOTS.getSlotIdx(), WidgetIndices.WornEquipmentTab.BOOTS_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.RING.getSlotIdx(), WidgetIndices.WornEquipmentTab.RING_DYNAMIC_CONTAINER },
-			{ EquipmentInventorySlot.AMMO.getSlotIdx(), WidgetIndices.WornEquipmentTab.AMMO_DYNAMIC_CONTAINER }
-	}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 
 	Equipment(final MethodContext ctx) {
 		super(ctx);
@@ -54,10 +37,6 @@ public class Equipment extends MethodProvider {
 		return methods.game.openTab(InterfaceTab.EQUIPMENT);
 	}
 
-	public static int getRuneliteIndexToWidgetChildIndex(int index) {
-		return runeliteIndexToWidgetChildIndex.get(index);
-	}
-
 	/**
 	 * Gets the equipment array.
 	 *
@@ -73,7 +52,7 @@ public class Equipment extends MethodProvider {
 		Item[] cachedItems = container.getItems();
 		for (int i = 0; i < cachedItems.length; i++) {
 			if (cachedItems[i].getId() != -1) {
-				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, runeliteIndexToWidgetChildIndex.get(i)).getDynamicComponent(1);
+				RSWidget slotItem = methods.interfaces.getComponent(WidgetIndices.WornEquipmentTab.GROUP_INDEX, i + WidgetIndices.WornEquipmentTab.HELMET_DYNAMIC_CONTAINER).getDynamicComponent(1);
 				items[i] = new RSItem(methods, slotItem, cachedItems[i]);
 			}
 		}
@@ -83,7 +62,7 @@ public class Equipment extends MethodProvider {
 	/**
 	 * Gets the equipment item at a given index.
 	 *
-	 * @param index The item index. See EquipmentInventorySlot
+	 * @param index The item index.
 	 * @return The equipped item.
 	 */
 	public RSItem getItem(int index) {
@@ -92,7 +71,7 @@ public class Equipment extends MethodProvider {
 			return null;
 		}
 		Item cachedItem = container.getItem(index);
-		RSWidget widget = getInterface().getComponent(runeliteIndexToWidgetChildIndex.get(index));
+		RSWidget widget = getInterface().getComponent(index);
 		return cachedItem == null ? null : new RSItem(methods, widget, cachedItem);
 	}
 

--- a/src/main/java/net/runelite/rsb/methods/Inventory.java
+++ b/src/main/java/net/runelite/rsb/methods/Inventory.java
@@ -63,6 +63,17 @@ public class Inventory extends MethodProvider {
 		return (widget.isValid() && widget.isVisible());
 	}
 
+	public boolean isOpen() {
+		return isOpen(getInterface().getValue());
+	}
+
+	public boolean open() {
+		if (!isOpen()) {
+			return methods.game.openTab(InterfaceTab.INVENTORY);
+		}
+		return true;
+	}
+
 	/**
 	 * Destroys any inventory items with the given ID.
 	 *

--- a/src/main/java/net/runelite/rsb/methods/RandomEvents.java
+++ b/src/main/java/net/runelite/rsb/methods/RandomEvents.java
@@ -22,6 +22,8 @@ public class RandomEvents extends MethodProvider {
     public void solveGenieLamp(Skill skillToLevel) {
         RSItem genieLamp = methods.inventory.getFirstWithAction("Rub");
         if (genieLamp != null) {
+            methods.inventory.open();
+            sleep(300);
             genieLamp.doAction("Rub");
             BooleanSupplier genieLampNotNull = () -> methods.client.getWidget(
                     WidgetIndices.GenieLampWindow.GROUP_INDEX,

--- a/src/main/java/net/runelite/rsb/wrappers/RSItem.java
+++ b/src/main/java/net/runelite/rsb/wrappers/RSItem.java
@@ -1,6 +1,7 @@
 package net.runelite.rsb.wrappers;
 
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.TileItem;
 import net.runelite.cache.definitions.ItemDefinition;
@@ -57,6 +58,14 @@ public class RSItem extends MethodProvider implements Clickable07, CacheProvider
 		this.id = item.getItemId();
 		this.stackSize = item.getStackSize();
 		this.component = item;
+		this.def = this.getDefinition(id);
+	}
+
+	public RSItem(final MethodContext ctx, final RSWidget widget, final Item item) {
+		super(ctx);
+		this.id = item.getId();
+		this.stackSize = item.getQuantity();
+		this.component = widget;
 		this.def = this.getDefinition(id);
 	}
 

--- a/src/main/java/net/runelite/rsb/wrappers/RSWidgetItem.java
+++ b/src/main/java/net/runelite/rsb/wrappers/RSWidgetItem.java
@@ -144,15 +144,6 @@ public class RSWidgetItem extends MethodProvider {
     }
 
     /**
-     * Gets the item's index in the parent widget
-     *
-     * @return item index
-     */
-    public int getItemIndex() {
-        return item.getIndex();
-    }
-
-    /**
      * Gets the stack size of the item
      *
      * @return the stack size

--- a/src/main/java/net/runelite/rsb/wrappers/client_wrapper/BaseClientWrapper.java
+++ b/src/main/java/net/runelite/rsb/wrappers/client_wrapper/BaseClientWrapper.java
@@ -2,10 +2,12 @@ package net.runelite.rsb.wrappers.client_wrapper;
 
 import net.runelite.api.*;
 import net.runelite.api.Point;
+import net.runelite.api.annotations.Varp;
 import net.runelite.api.clan.ClanChannel;
 import net.runelite.api.clan.ClanSettings;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.dbtable.DBRowConfig;
 import net.runelite.api.hooks.Callbacks;
 import net.runelite.api.hooks.DrawCallbacks;
 import net.runelite.api.vars.AccountType;
@@ -536,12 +538,6 @@ public abstract class BaseClientWrapper extends Applet implements Client {
 
     @Override
     @Deprecated
-    public int getVar(VarPlayer varPlayer) {
-        return wrappedClient.getVar(varPlayer);
-    }
-
-    @Override
-    @Deprecated
     public int getVar(int varbit) {
         return wrappedClient.getVar(varbit);
     }
@@ -557,12 +553,7 @@ public abstract class BaseClientWrapper extends Applet implements Client {
     }
 
     @Override
-    public int getVarpValue(VarPlayer varPlayer) {
-        return wrappedClient.getVarpValue(varPlayer);
-    }
-
-    @Override
-    public int getVarpValue(int varpId) {
+    public int getVarpValue(@Varp int varpId) {
         return wrappedClient.getVarpValue(varpId);
     }
 
@@ -685,6 +676,11 @@ public abstract class BaseClientWrapper extends Applet implements Client {
     @Override
     public Object getDBTableField(int rowID, int column, int tupleIndex, int fieldIndex) {
         return wrappedClient.getDBTableField(rowID, column, tupleIndex, fieldIndex);
+    }
+
+    @Override
+    public DBRowConfig getDBRowConfig(int rowID) {
+        return wrappedClient.getDBRowConfig(rowID);
     }
 
     public MapElementConfig getMapElementConfig(int id) {
@@ -1117,13 +1113,6 @@ public abstract class BaseClientWrapper extends Applet implements Client {
     public boolean isInInstancedRegion() {
         return wrappedClient.isInInstancedRegion();
     }
-
-    @Override
-    @Deprecated
-    public int getItemPressedDuration() {
-        return wrappedClient.getItemPressedDuration();
-    }
-
     @Override
     @Nullable
     public CollisionData[] getCollisionMaps() {
@@ -1315,19 +1304,6 @@ public abstract class BaseClientWrapper extends Applet implements Client {
     public void checkClickbox(Model model, int orientation, int pitchSin, int pitchCos, int yawSin, int yawCos, int x, int y, int z, long hash) {
         wrappedClient.checkClickbox(model, orientation, pitchSin, pitchCos, yawSin, yawCos, x, y, z, hash);
     }
-
-    @Override
-    @Deprecated
-    public Widget getIf1DraggedWidget() {
-        return wrappedClient.getIf1DraggedWidget();
-    }
-
-    @Override
-    @Deprecated
-    public int getIf1DraggedItemIndex() {
-        return wrappedClient.getIf1DraggedItemIndex();
-    }
-
     @Override
     public boolean isWidgetSelected() {
         return wrappedClient.isWidgetSelected();
@@ -1337,19 +1313,6 @@ public abstract class BaseClientWrapper extends Applet implements Client {
     public void setWidgetSelected(boolean selected) {
         wrappedClient.setWidgetSelected(selected);
     }
-
-    @Override
-    @Deprecated
-    public int getSelectedItem() {
-        return wrappedClient.getSelectedItem();
-    }
-
-    @Override
-    @Deprecated
-    public int getSelectedItemIndex() {
-        return wrappedClient.getSelectedItemIndex();
-    }
-
     @Override
     @Nullable
     public Widget getSelectedWidget() {

--- a/src/main/java/net/runelite/rsb/wrappers/client_wrapper/BaseWidgetWrapper.java
+++ b/src/main/java/net/runelite/rsb/wrappers/client_wrapper/BaseWidgetWrapper.java
@@ -3,7 +3,6 @@ package net.runelite.rsb.wrappers.client_wrapper;
 import net.runelite.api.FontTypeFace;
 import net.runelite.api.Point;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetItem;
 
 import javax.annotation.Nullable;
 import java.awt.*;
@@ -306,19 +305,6 @@ public abstract class BaseWidgetWrapper implements Widget {
     public Rectangle getBounds() {
         return wrappedWidget.getBounds();
     }
-
-    @Override
-    @Deprecated
-    public Collection<WidgetItem> getWidgetItems() {
-        return wrappedWidget.getWidgetItems();
-    }
-
-    @Override
-    @Deprecated
-    public WidgetItem getWidgetItem(int index) {
-        return wrappedWidget.getWidgetItem(index);
-    }
-
     @Override
     public int getItemId() {
         return wrappedWidget.getItemId();

--- a/src/main/java/net/runelite/rsb/wrappers/client_wrapper/RSClient.java
+++ b/src/main/java/net/runelite/rsb/wrappers/client_wrapper/RSClient.java
@@ -6,7 +6,6 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.worldmap.MapElementConfig;
-import net.runelite.api.worldmap.WorldMap;
 import net.runelite.client.callback.ClientThread;
 
 import javax.annotation.Nullable;
@@ -126,12 +125,6 @@ public class RSClient extends BaseClientWrapper {
     public Widget getWidget(int packedID) { // tested, no need to runOnClientThread
         return convertResult(super.getWidget(packedID));
     }
-
-    @Override
-    public int getVarpValue(VarPlayer varPlayer) {
-        return convertResult(super.getVarpValue(varPlayer));
-    }
-
     @Override
     public MapElementConfig getMapElementConfig(int id) {
         return convertResult(super.getMapElementConfig(id));
@@ -157,13 +150,6 @@ public class RSClient extends BaseClientWrapper {
     public void setHintArrow(LocalPoint point) {
         super.setHintArrow(point);
     }
-
-    @Override
-    @Deprecated
-    public Widget getIf1DraggedWidget() {
-        return convertResult(super.getIf1DraggedWidget());
-    }
-
     @Override
     public boolean isWidgetSelected() {return false;}
 

--- a/src/main/java/net/runelite/rsb/wrappers/common/CacheProvider.java
+++ b/src/main/java/net/runelite/rsb/wrappers/common/CacheProvider.java
@@ -32,6 +32,7 @@ public interface CacheProvider<T> {
 
     private static void fillCacheFromDirectory(File dir, String className) {
         File[] directoryListing = dir.listFiles();
+
         for (File file : directoryListing) {
             if (file.getName().contains(".json")) {
                 fileCache.put(Integer.parseInt(file.getName().replace(".json", "")) + className, file);


### PR DESCRIPTION
Relies on the inventory one so review and pull that first. Also I got merge conflicts not sure why. Get rid of getInterface(boolean) and only keep the changed getInterface(). This also breaks DaxWalker but it was already broken anyways. There is a PR to fix it though in the Dax repo