### PR TITLE
hasMoved logic change

### DIFF
--- a/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
+++ b/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
@@ -46,7 +46,9 @@ public class RSPlayer extends RSCharacter {
 	public boolean isMoving() {
 		var poseAnimation = getAccessor().getPoseAnimation();
 		return isLocalPlayerMoving()
-				|| poseAnimation == getAnimation()
+				|| poseAnimation == getAccessor().getWalkRotate180()
+				|| poseAnimation == getAccessor().getWalkRotateLeft()
+				|| poseAnimation == getAccessor().getWalkRotateRight()
 				|| poseAnimation == getAccessor().getRunAnimation()
 				|| poseAnimation == getAccessor().getWalkAnimation();
 	}

--- a/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
+++ b/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
@@ -15,8 +15,6 @@ public class RSPlayer extends RSCharacter {
 
 	private final SoftReference<Player> p;
 
-	private RSTile previous_tile;
-
 	public RSPlayer(final MethodContext ctx, final Player p) {
 		super(ctx);
 		this.p = new SoftReference<>(p);
@@ -45,10 +43,9 @@ public class RSPlayer extends RSCharacter {
 		return false;
 	}
 
-	public boolean isMoving() {
-		boolean isMoving = previous_tile != null && !getLocation().equals(previous_tile);
-		previous_tile = getLocation();
-		return isLocalPlayerMoving() || isMoving;
+	public boolean hasMoved() {
+		var poseAnimation = getAccessor().getPoseAnimation();
+		return poseAnimation == getAnimation() || poseAnimation == getAccessor().getRunAnimation() || poseAnimation == getAccessor().getWalkAnimation();
 	}
 
 	@Override

--- a/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
+++ b/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
@@ -45,7 +45,10 @@ public class RSPlayer extends RSCharacter {
 
 	public boolean isMoving() {
 		var poseAnimation = getAccessor().getPoseAnimation();
-		return poseAnimation == getAnimation() || poseAnimation == getAccessor().getRunAnimation() || poseAnimation == getAccessor().getWalkAnimation();
+		return isLocalPlayerMoving()
+				|| poseAnimation == getAnimation()
+				|| poseAnimation == getAccessor().getRunAnimation()
+				|| poseAnimation == getAccessor().getWalkAnimation();
 	}
 
 	@Override

--- a/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
+++ b/src/main/java/net/runelite/rsb/wrappers/RSPlayer.java
@@ -43,7 +43,7 @@ public class RSPlayer extends RSCharacter {
 		return false;
 	}
 
-	public boolean hasMoved() {
+	public boolean isMoving() {
 		var poseAnimation = getAccessor().getPoseAnimation();
 		return poseAnimation == getAnimation() || poseAnimation == getAccessor().getRunAnimation() || poseAnimation == getAccessor().getWalkAnimation();
 	}


### PR DESCRIPTION
After a discussion with the community and own tests, using pose animation comparisons are a better solution than comparing the previous tile stored in the memory.