### PR TITLE
Block mouse input when script is running

### DIFF
--- a/src/main/java/net/runelite/rsb/internal/ScriptHandler.java
+++ b/src/main/java/net/runelite/rsb/internal/ScriptHandler.java
@@ -60,7 +60,6 @@ public class ScriptHandler {
 			randoms.add(new SystemUpdate());
 
 			 */
-
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -144,7 +143,6 @@ public class ScriptHandler {
 	public void runScript(Script script) {
 		script.init(bot.getMethodContext());
 		for (ScriptListener l : listeners) {
-			System.out.println(l.getClass().getName());
 			l.scriptStarted(this, script);
 		}
 		ScriptManifest prop = script.getClass().getAnnotation(ScriptManifest.class);

--- a/src/main/java/net/runelite/rsb/internal/ScriptHandler.java
+++ b/src/main/java/net/runelite/rsb/internal/ScriptHandler.java
@@ -12,26 +12,26 @@ import java.util.*;
 
 public class ScriptHandler {
 
-    private final ArrayList<net.runelite.rsb.script.Random> randoms = new ArrayList<>();
-    private final HashMap<Integer, Script> scripts = new HashMap<>();
-    private final HashMap<Integer, Thread> scriptThreads = new HashMap<>();
+	private final ArrayList<net.runelite.rsb.script.Random> randoms = new ArrayList<>();
+	private final HashMap<Integer, Script> scripts = new HashMap<>();
+	private final HashMap<Integer, Thread> scriptThreads = new HashMap<>();
 
-    private final Set<ScriptListener> listeners = Collections.synchronizedSet(new HashSet<>());
+	private final Set<ScriptListener> listeners = Collections.synchronizedSet(new HashSet<>());
 
-    private final BotLite bot;
+	private final BotLite bot;
 
-    private MouseInputBlocker mouseInputBlocker;
-    private MouseMotionBlocker mouseMotionBlocker;
+	private MouseInputBlocker mouseInputBlocker;
+	private MouseMotionBlocker mouseMotionBlocker;
 
-    public ScriptHandler(BotLite bot) {
-        this.bot = bot;
-        listeners.add(new MouseInputBlocker(bot));
-        listeners.add(new MouseMotionBlocker(bot));
-    }
+	public ScriptHandler(BotLite bot) {
+		this.bot = bot;
+		listeners.add(new MouseInputBlocker(bot));
+		listeners.add(new MouseMotionBlocker(bot));
+	}
 
-    public void init() {
-        try {
-            randoms.add(new LoginBot());
+	public void init() {
+		try {
+			randoms.add(new LoginBot());
 			/*
 			randoms.add(new BankPins());
 			randoms.add(new BeehiveSolver());
@@ -61,162 +61,162 @@ public class ScriptHandler {
 
 			 */
 
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        for (net.runelite.rsb.script.Random r : randoms) {
-            r.init(bot.getMethodContext());
-        }
-    }
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		for (net.runelite.rsb.script.Random r : randoms) {
+			r.init(bot.getMethodContext());
+		}
+	}
 
-    public void addScriptListener(ScriptListener l) {
-        listeners.add(l);
-    }
+	public void addScriptListener(ScriptListener l) {
+		listeners.add(l);
+	}
 
-    public void removeScriptListener(ScriptListener l) {
-        listeners.remove(l);
-    }
+	public void removeScriptListener(ScriptListener l) {
+		listeners.remove(l);
+	}
 
-    private void addScriptToPool(Script ss, Thread t) {
-        for (int off = 0; off < scripts.size(); ++off) {
-            if (!scripts.containsKey(off)) {
-                scripts.put(off, ss);
-                ss.setID(off);
-                scriptThreads.put(off, t);
-                return;
-            }
-        }
-        ss.setID(scripts.size());
-        scripts.put(scripts.size(), ss);
-        scriptThreads.put(scriptThreads.size(), t);
-    }
+	private void addScriptToPool(Script ss, Thread t) {
+		for (int off = 0; off < scripts.size(); ++off) {
+			if (!scripts.containsKey(off)) {
+				scripts.put(off, ss);
+				ss.setID(off);
+				scriptThreads.put(off, t);
+				return;
+			}
+		}
+		ss.setID(scripts.size());
+		scripts.put(scripts.size(), ss);
+		scriptThreads.put(scriptThreads.size(), t);
+	}
 
-    public BotLite getBot() {
-        return bot;
-    }
+	public BotLite getBot() {
+		return bot;
+	}
 
-    public Collection<net.runelite.rsb.script.Random> getRandoms() {
-        return randoms;
-    }
+	public Collection<net.runelite.rsb.script.Random> getRandoms() {
+		return randoms;
+	}
 
-    public Map<Integer, Script> getRunningScripts() {
-        return Collections.unmodifiableMap(scripts);
-    }
+	public Map<Integer, Script> getRunningScripts() {
+		return Collections.unmodifiableMap(scripts);
+	}
 
-    public void pauseScript(int id) {
-        Script s = scripts.get(id);
-        s.setPaused(!s.isPaused());
-        if (s.isPaused()) {
-            for (ScriptListener l : listeners) {
-                l.scriptPaused(this, s);
-            }
-        } else {
-            for (ScriptListener l : listeners) {
-                l.scriptResumed(this, s);
-            }
-        }
-    }
+	public void pauseScript(int id) {
+		Script s = scripts.get(id);
+		s.setPaused(!s.isPaused());
+		if (s.isPaused()) {
+			for (ScriptListener l : listeners) {
+				l.scriptPaused(this, s);
+			}
+		} else {
+			for (ScriptListener l : listeners) {
+				l.scriptResumed(this, s);
+			}
+		}
+	}
 
-    public void stopScript(int id) {
-        Script script = scripts.get(id);
-        if (script != null) {
-            script.deactivate(id);
-            scripts.remove(id);
-            scriptThreads.remove(id);
-            for (ScriptListener l : listeners) {
-                l.scriptStopped(this, script);
-            }
-        }
-    }
+	public void stopScript(int id) {
+		Script script = scripts.get(id);
+		if (script != null) {
+			script.deactivate(id);
+			scripts.remove(id);
+			scriptThreads.remove(id);
+			for (ScriptListener l : listeners) {
+				l.scriptStopped(this, script);
+			}
+		}
+	}
 
-    public boolean onBreak(int id) {
-        Script script = scripts.get(id);
-        return script != null && script.onBreakStart();
-    }
+	public boolean onBreak(int id) {
+		Script script = scripts.get(id);
+		return script != null && script.onBreakStart();
+	}
 
-    public void onBreakConclude(int id) {
-        Script script = scripts.get(id);
-        if (script != null) {
-            script.onBreakFinish();
-        }
-    }
+	public void onBreakConclude(int id) {
+		Script script = scripts.get(id);
+		if (script != null) {
+			script.onBreakFinish();
+		}
+	}
 
-    public void runScript(Script script) {
-        script.init(bot.getMethodContext());
-        for (ScriptListener l : listeners) {
-            System.out.println(l.getClass().getName());
-            l.scriptStarted(this, script);
-        }
-        ScriptManifest prop = script.getClass().getAnnotation(ScriptManifest.class);
-        Thread t = new Thread(script, "Script-" + prop.name());
-        addScriptToPool(script, t);
-        t.start();
-    }
+	public void runScript(Script script) {
+		script.init(bot.getMethodContext());
+		for (ScriptListener l : listeners) {
+			System.out.println(l.getClass().getName());
+			l.scriptStarted(this, script);
+		}
+		ScriptManifest prop = script.getClass().getAnnotation(ScriptManifest.class);
+		Thread t = new Thread(script, "Script-" + prop.name());
+		addScriptToPool(script, t);
+		t.start();
+	}
 
-    public void stopAllScripts() {
-        Set<Integer> theSet = scripts.keySet();
-        int[] arr = new int[theSet.size()];
-        int c = 0;
-        for (int i : theSet) {
-            arr[c] = i;
-            c++;
-        }
-        for (int id : arr) {
-            stopScript(id);
-        }
-    }
+	public void stopAllScripts() {
+		Set<Integer> theSet = scripts.keySet();
+		int[] arr = new int[theSet.size()];
+		int c = 0;
+		for (int i : theSet) {
+			arr[c] = i;
+			c++;
+		}
+		for (int id : arr) {
+			stopScript(id);
+		}
+	}
 
-    public void stopScript() {
-        Thread curThread = Thread.currentThread();
-        for (int i = 0; i < scripts.size(); i++) {
-            Script script = scripts.get(i);
-            if (script != null && script.isRunning()) {
-                if (scriptThreads.get(i) == curThread) {
-                    stopScript(i);
-                }
-            }
-        }
-        if (curThread == null) {
-            throw new ThreadDeath();
-        }
-    }
+	public void stopScript() {
+		Thread curThread = Thread.currentThread();
+		for (int i = 0; i < scripts.size(); i++) {
+			Script script = scripts.get(i);
+			if (script != null && script.isRunning()) {
+				if (scriptThreads.get(i) == curThread) {
+					stopScript(i);
+				}
+			}
+		}
+		if (curThread == null) {
+			throw new ThreadDeath();
+		}
+	}
 
-    public boolean onBreak() {
-        Thread curThread = Thread.currentThread();
-        for (int i = 0; i < scripts.size(); i++) {
-            Script script = scripts.get(i);
-            if (script != null && script.isRunning()) {
-                if (scriptThreads.get(i) == curThread) {
-                    return onBreak(i);
-                }
-            }
-        }
-        if (curThread == null) {
-            throw new ThreadDeath();
-        }
-        return false;
-    }
+	public boolean onBreak() {
+		Thread curThread = Thread.currentThread();
+		for (int i = 0; i < scripts.size(); i++) {
+			Script script = scripts.get(i);
+			if (script != null && script.isRunning()) {
+				if (scriptThreads.get(i) == curThread) {
+					return onBreak(i);
+				}
+			}
+		}
+		if (curThread == null) {
+			throw new ThreadDeath();
+		}
+		return false;
+	}
 
-    public void onBreakResume() {
-        Thread curThread = Thread.currentThread();
-        for (int i = 0; i < scripts.size(); i++) {
-            Script script = scripts.get(i);
-            if (script != null && script.isRunning()) {
-                if (scriptThreads.get(i) == curThread) {
-                    onBreakConclude(i);
-                    return;
-                }
-            }
-        }
-        if (curThread == null) {
-            throw new ThreadDeath();
-        }
-    }
+	public void onBreakResume() {
+		Thread curThread = Thread.currentThread();
+		for (int i = 0; i < scripts.size(); i++) {
+			Script script = scripts.get(i);
+			if (script != null && script.isRunning()) {
+				if (scriptThreads.get(i) == curThread) {
+					onBreakConclude(i);
+					return;
+				}
+			}
+		}
+		if (curThread == null) {
+			throw new ThreadDeath();
+		}
+	}
 
-    public void updateInput(BotLite bot, int mask) {
-        for (ScriptListener l : listeners) {
-            l.inputChanged(bot, mask);
-        }
-    }
+	public void updateInput(BotLite bot, int mask) {
+		for (ScriptListener l : listeners) {
+			l.inputChanged(bot, mask);
+		}
+	}
 
 }

--- a/src/main/java/net/runelite/rsb/internal/ScriptHandler.java
+++ b/src/main/java/net/runelite/rsb/internal/ScriptHandler.java
@@ -25,6 +25,8 @@ public class ScriptHandler {
 
     public ScriptHandler(BotLite bot) {
         this.bot = bot;
+        listeners.add(new MouseInputBlocker(bot));
+        listeners.add(new MouseMotionBlocker(bot));
     }
 
     public void init() {
@@ -59,8 +61,6 @@ public class ScriptHandler {
 
 			 */
 
-            listeners.add(new MouseInputBlocker(bot));
-            listeners.add(new MouseMotionBlocker(bot));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -144,6 +144,7 @@ public class ScriptHandler {
     public void runScript(Script script) {
         script.init(bot.getMethodContext());
         for (ScriptListener l : listeners) {
+            System.out.println(l.getClass().getName());
             l.scriptStarted(this, script);
         }
         ScriptManifest prop = script.getClass().getAnnotation(ScriptManifest.class);

--- a/src/main/java/net/runelite/rsb/internal/input/MouseInputBlocker.java
+++ b/src/main/java/net/runelite/rsb/internal/input/MouseInputBlocker.java
@@ -19,14 +19,16 @@ public class MouseInputBlocker implements MouseListener, ScriptListener {
     }
 
     private void blockInput() {
-        Canvas c = bot.getCanvas();
+        if(bot.client == null) return;
+        java.awt.Canvas c = bot.client.getCanvas();
         mouseListeners = c.getMouseListeners();
         Arrays.stream(mouseListeners).forEach(c::removeMouseListener);
         c.addMouseListener(this);
     }
 
     private void unblockInput() {
-        Canvas c = bot.getCanvas();
+        if(bot.client == null) return;
+        java.awt.Canvas c = bot.client.getCanvas();
         c.removeMouseListener(this);
         Arrays.stream(mouseListeners).forEach(c::addMouseListener);
     }
@@ -53,7 +55,7 @@ public class MouseInputBlocker implements MouseListener, ScriptListener {
 
     @Override
     public void inputChanged(BotLite bot, int mask) {
-        
+
     }
 
     @Override
@@ -100,6 +102,5 @@ public class MouseInputBlocker implements MouseListener, ScriptListener {
             l.mouseExited(e);
         }
     }
-
 
 }

--- a/src/main/java/net/runelite/rsb/internal/input/MouseInputBlocker.java
+++ b/src/main/java/net/runelite/rsb/internal/input/MouseInputBlocker.java
@@ -1,0 +1,105 @@
+package net.runelite.rsb.internal.input;
+
+import net.runelite.rsb.botLauncher.BotLite;
+import net.runelite.rsb.internal.ScriptHandler;
+import net.runelite.rsb.internal.listener.ScriptListener;
+import net.runelite.rsb.script.Script;
+
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.Arrays;
+
+public class MouseInputBlocker implements MouseListener, ScriptListener {
+
+    private final BotLite bot;
+    private MouseListener[] mouseListeners;
+
+    public MouseInputBlocker(BotLite bot) {
+        this.bot = bot;
+    }
+
+    private void blockInput() {
+        Canvas c = bot.getCanvas();
+        mouseListeners = c.getMouseListeners();
+        Arrays.stream(mouseListeners).forEach(c::removeMouseListener);
+        c.addMouseListener(this);
+    }
+
+    private void unblockInput() {
+        Canvas c = bot.getCanvas();
+        c.removeMouseListener(this);
+        Arrays.stream(mouseListeners).forEach(c::addMouseListener);
+    }
+
+    @Override
+    public void scriptStarted(ScriptHandler handler, Script script) {
+        blockInput();
+    }
+
+    @Override
+    public void scriptStopped(ScriptHandler handler, Script script) {
+        unblockInput();
+    }
+
+    @Override
+    public void scriptResumed(ScriptHandler handler, Script script) {
+        blockInput();
+    }
+
+    @Override
+    public void scriptPaused(ScriptHandler handler, Script script) {
+        unblockInput();
+    }
+
+    @Override
+    public void inputChanged(BotLite bot, int mask) {
+        
+    }
+
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseListener l : mouseListeners) {
+            if (e.isConsumed()) break;
+            l.mouseClicked(e);
+        }
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseListener l : mouseListeners) {
+            if (e.isConsumed()) break;
+            l.mousePressed(e);
+        }
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseListener l : mouseListeners) {
+            if (e.isConsumed()) break;
+            l.mouseReleased(e);
+        }
+    }
+
+    @Override
+    public void mouseEntered(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseListener l : mouseListeners) {
+            if (e.isConsumed()) break;
+            l.mouseEntered(e);
+        }
+    }
+
+    @Override
+    public void mouseExited(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseListener l : mouseListeners) {
+            if (e.isConsumed()) break;
+            l.mouseExited(e);
+        }
+    }
+
+
+}

--- a/src/main/java/net/runelite/rsb/internal/input/MouseInputBlocker.java
+++ b/src/main/java/net/runelite/rsb/internal/input/MouseInputBlocker.java
@@ -11,96 +11,96 @@ import java.util.Arrays;
 
 public class MouseInputBlocker implements MouseListener, ScriptListener {
 
-    private final BotLite bot;
-    private MouseListener[] mouseListeners;
+	private final BotLite bot;
+	private MouseListener[] mouseListeners;
 
-    public MouseInputBlocker(BotLite bot) {
-        this.bot = bot;
-    }
+	public MouseInputBlocker(BotLite bot) {
+		this.bot = bot;
+	}
 
-    private void blockInput() {
-        if(bot.client == null) return;
-        java.awt.Canvas c = bot.client.getCanvas();
-        mouseListeners = c.getMouseListeners();
-        Arrays.stream(mouseListeners).forEach(c::removeMouseListener);
-        c.addMouseListener(this);
-    }
+	private void blockInput() {
+		if (bot.client == null) return;
+		java.awt.Canvas c = bot.client.getCanvas();
+		mouseListeners = c.getMouseListeners();
+		Arrays.stream(mouseListeners).forEach(c::removeMouseListener);
+		c.addMouseListener(this);
+	}
 
-    private void unblockInput() {
-        if(bot.client == null) return;
-        java.awt.Canvas c = bot.client.getCanvas();
-        c.removeMouseListener(this);
-        Arrays.stream(mouseListeners).forEach(c::addMouseListener);
-    }
+	private void unblockInput() {
+		if (bot.client == null) return;
+		java.awt.Canvas c = bot.client.getCanvas();
+		c.removeMouseListener(this);
+		Arrays.stream(mouseListeners).forEach(c::addMouseListener);
+	}
 
-    @Override
-    public void scriptStarted(ScriptHandler handler, Script script) {
-        blockInput();
-    }
+	@Override
+	public void scriptStarted(ScriptHandler handler, Script script) {
+		blockInput();
+	}
 
-    @Override
-    public void scriptStopped(ScriptHandler handler, Script script) {
-        unblockInput();
-    }
+	@Override
+	public void scriptStopped(ScriptHandler handler, Script script) {
+		unblockInput();
+	}
 
-    @Override
-    public void scriptResumed(ScriptHandler handler, Script script) {
-        blockInput();
-    }
+	@Override
+	public void scriptResumed(ScriptHandler handler, Script script) {
+		blockInput();
+	}
 
-    @Override
-    public void scriptPaused(ScriptHandler handler, Script script) {
-        unblockInput();
-    }
+	@Override
+	public void scriptPaused(ScriptHandler handler, Script script) {
+		unblockInput();
+	}
 
-    @Override
-    public void inputChanged(BotLite bot, int mask) {
+	@Override
+	public void inputChanged(BotLite bot, int mask) {
 
-    }
+	}
 
-    @Override
-    public void mouseClicked(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseListener l : mouseListeners) {
-            if (e.isConsumed()) break;
-            l.mouseClicked(e);
-        }
-    }
+	@Override
+	public void mouseClicked(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseListener l : mouseListeners) {
+			if (e.isConsumed()) break;
+			l.mouseClicked(e);
+		}
+	}
 
-    @Override
-    public void mousePressed(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseListener l : mouseListeners) {
-            if (e.isConsumed()) break;
-            l.mousePressed(e);
-        }
-    }
+	@Override
+	public void mousePressed(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseListener l : mouseListeners) {
+			if (e.isConsumed()) break;
+			l.mousePressed(e);
+		}
+	}
 
-    @Override
-    public void mouseReleased(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseListener l : mouseListeners) {
-            if (e.isConsumed()) break;
-            l.mouseReleased(e);
-        }
-    }
+	@Override
+	public void mouseReleased(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseListener l : mouseListeners) {
+			if (e.isConsumed()) break;
+			l.mouseReleased(e);
+		}
+	}
 
-    @Override
-    public void mouseEntered(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseListener l : mouseListeners) {
-            if (e.isConsumed()) break;
-            l.mouseEntered(e);
-        }
-    }
+	@Override
+	public void mouseEntered(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseListener l : mouseListeners) {
+			if (e.isConsumed()) break;
+			l.mouseEntered(e);
+		}
+	}
 
-    @Override
-    public void mouseExited(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseListener l : mouseListeners) {
-            if (e.isConsumed()) break;
-            l.mouseExited(e);
-        }
-    }
+	@Override
+	public void mouseExited(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseListener l : mouseListeners) {
+			if (e.isConsumed()) break;
+			l.mouseExited(e);
+		}
+	}
 
 }

--- a/src/main/java/net/runelite/rsb/internal/input/MouseMotionBlocker.java
+++ b/src/main/java/net/runelite/rsb/internal/input/MouseMotionBlocker.java
@@ -11,68 +11,68 @@ import java.util.Arrays;
 
 public class MouseMotionBlocker implements MouseMotionListener, ScriptListener {
 
-    private final BotLite bot;
-    private MouseMotionListener[] mouseMotionListeners;
+	private final BotLite bot;
+	private MouseMotionListener[] mouseMotionListeners;
 
-    public MouseMotionBlocker(BotLite bot) {
-        this.bot = bot;
-    }
+	public MouseMotionBlocker(BotLite bot) {
+		this.bot = bot;
+	}
 
-    private void blockInput() {
-        if(bot.client == null) return;
-        java.awt.Canvas c = bot.client.getCanvas();
-        mouseMotionListeners = c.getMouseMotionListeners();
-        Arrays.stream(mouseMotionListeners).forEach(c::removeMouseMotionListener);
-        c.addMouseMotionListener(this);
-    }
+	private void blockInput() {
+		if (bot.client == null) return;
+		java.awt.Canvas c = bot.client.getCanvas();
+		mouseMotionListeners = c.getMouseMotionListeners();
+		Arrays.stream(mouseMotionListeners).forEach(c::removeMouseMotionListener);
+		c.addMouseMotionListener(this);
+	}
 
-    private void unblockInput() {
-        if(bot.client == null) return;
-        java.awt.Canvas c = bot.client.getCanvas();
-        c.removeMouseMotionListener(this);
-        Arrays.stream(mouseMotionListeners).forEach(c::addMouseMotionListener);
-    }
+	private void unblockInput() {
+		if (bot.client == null) return;
+		java.awt.Canvas c = bot.client.getCanvas();
+		c.removeMouseMotionListener(this);
+		Arrays.stream(mouseMotionListeners).forEach(c::addMouseMotionListener);
+	}
 
-    @Override
-    public void scriptStarted(ScriptHandler handler, Script script) {
-        blockInput();
-    }
+	@Override
+	public void scriptStarted(ScriptHandler handler, Script script) {
+		blockInput();
+	}
 
-    @Override
-    public void scriptStopped(ScriptHandler handler, Script script) {
-        unblockInput();
-    }
+	@Override
+	public void scriptStopped(ScriptHandler handler, Script script) {
+		unblockInput();
+	}
 
-    @Override
-    public void scriptResumed(ScriptHandler handler, Script script) {
-        blockInput();
-    }
+	@Override
+	public void scriptResumed(ScriptHandler handler, Script script) {
+		blockInput();
+	}
 
-    @Override
-    public void scriptPaused(ScriptHandler handler, Script script) {
-        unblockInput();
-    }
+	@Override
+	public void scriptPaused(ScriptHandler handler, Script script) {
+		unblockInput();
+	}
 
-    @Override
-    public void inputChanged(BotLite bot, int mask) {
-        
-    }
+	@Override
+	public void inputChanged(BotLite bot, int mask) {
 
-    @Override
-    public void mouseDragged(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseMotionListener l : mouseMotionListeners) {
-            if (e.isConsumed()) break;
-            l.mouseDragged(e);
-        }
-    }
+	}
 
-    @Override
-    public void mouseMoved(MouseEvent e) {
-        if (!e.getSource().getClass().getName().equals("client")) e.consume();
-        for (MouseMotionListener l : mouseMotionListeners) {
-            if (e.isConsumed()) break;
-            l.mouseMoved(e);
-        }
-    }
+	@Override
+	public void mouseDragged(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseMotionListener l : mouseMotionListeners) {
+			if (e.isConsumed()) break;
+			l.mouseDragged(e);
+		}
+	}
+
+	@Override
+	public void mouseMoved(MouseEvent e) {
+		if (!e.getSource().getClass().getName().equals("client")) e.consume();
+		for (MouseMotionListener l : mouseMotionListeners) {
+			if (e.isConsumed()) break;
+			l.mouseMoved(e);
+		}
+	}
 }

--- a/src/main/java/net/runelite/rsb/internal/input/MouseMotionBlocker.java
+++ b/src/main/java/net/runelite/rsb/internal/input/MouseMotionBlocker.java
@@ -19,14 +19,16 @@ public class MouseMotionBlocker implements MouseMotionListener, ScriptListener {
     }
 
     private void blockInput() {
-        Canvas c = bot.getCanvas();
+        if(bot.client == null) return;
+        java.awt.Canvas c = bot.client.getCanvas();
         mouseMotionListeners = c.getMouseMotionListeners();
         Arrays.stream(mouseMotionListeners).forEach(c::removeMouseMotionListener);
         c.addMouseMotionListener(this);
     }
 
     private void unblockInput() {
-        Canvas c = bot.getCanvas();
+        if(bot.client == null) return;
+        java.awt.Canvas c = bot.client.getCanvas();
         c.removeMouseMotionListener(this);
         Arrays.stream(mouseMotionListeners).forEach(c::addMouseMotionListener);
     }

--- a/src/main/java/net/runelite/rsb/internal/input/MouseMotionBlocker.java
+++ b/src/main/java/net/runelite/rsb/internal/input/MouseMotionBlocker.java
@@ -1,0 +1,76 @@
+package net.runelite.rsb.internal.input;
+
+import net.runelite.rsb.botLauncher.BotLite;
+import net.runelite.rsb.internal.ScriptHandler;
+import net.runelite.rsb.internal.listener.ScriptListener;
+import net.runelite.rsb.script.Script;
+
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionListener;
+import java.util.Arrays;
+
+public class MouseMotionBlocker implements MouseMotionListener, ScriptListener {
+
+    private final BotLite bot;
+    private MouseMotionListener[] mouseMotionListeners;
+
+    public MouseMotionBlocker(BotLite bot) {
+        this.bot = bot;
+    }
+
+    private void blockInput() {
+        Canvas c = bot.getCanvas();
+        mouseMotionListeners = c.getMouseMotionListeners();
+        Arrays.stream(mouseMotionListeners).forEach(c::removeMouseMotionListener);
+        c.addMouseMotionListener(this);
+    }
+
+    private void unblockInput() {
+        Canvas c = bot.getCanvas();
+        c.removeMouseMotionListener(this);
+        Arrays.stream(mouseMotionListeners).forEach(c::addMouseMotionListener);
+    }
+
+    @Override
+    public void scriptStarted(ScriptHandler handler, Script script) {
+        blockInput();
+    }
+
+    @Override
+    public void scriptStopped(ScriptHandler handler, Script script) {
+        unblockInput();
+    }
+
+    @Override
+    public void scriptResumed(ScriptHandler handler, Script script) {
+        blockInput();
+    }
+
+    @Override
+    public void scriptPaused(ScriptHandler handler, Script script) {
+        unblockInput();
+    }
+
+    @Override
+    public void inputChanged(BotLite bot, int mask) {
+        
+    }
+
+    @Override
+    public void mouseDragged(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseMotionListener l : mouseMotionListeners) {
+            if (e.isConsumed()) break;
+            l.mouseDragged(e);
+        }
+    }
+
+    @Override
+    public void mouseMoved(MouseEvent e) {
+        if (!e.getSource().getClass().getName().equals("client")) e.consume();
+        for (MouseMotionListener l : mouseMotionListeners) {
+            if (e.isConsumed()) break;
+            l.mouseMoved(e);
+        }
+    }
+}


### PR DESCRIPTION
These changes make it so a user mouse clicks and motion do not override the bot mouse movements when a script is running and is not paused.

It does so by de-registering the mouse listeners when a script starts and putting a listener in between that determines whether mouse inputs come from the client or from the user. When the script stops the mouse listeners are re-registered and the middleman is de-registered,